### PR TITLE
Support only Python 3.5.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ python: 3.5
 
 env:
   - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
   - TOXENV=py27
-  - TOXENV=py26
   - TOXENV=pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
@@ -17,5 +14,3 @@ install: pip install -U tox
 
 # command to run tests, e.g. python setup.py test
 script: tox -e ${TOXENV}
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ python: 3.5
 
 env:
   - TOXENV=py35
-  - TOXENV=py27
-  - TOXENV=pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,3 +7,4 @@ tox==2.3.1
 coverage==4.1
 Sphinx==1.4.4
 pytest==2.9.2
+mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ requirements = [
 ]
 
 test_requirements = [
-    'pytest'
+    'pytest',
+    'mock'
 ]
 
 setup(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import socket
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 import pytest
 from click.testing import CliRunner

--- a/tests/test_metricz.py
+++ b/tests/test_metricz.py
@@ -5,7 +5,7 @@ from metricz import MetricWriter
 from metricz.metricz import KAIROSDB_URL
 
 import datetime
-from unittest.mock import MagicMock, ANY
+from mock import MagicMock, ANY
 import pytest
 
 


### PR DESCRIPTION
Support only Python 3.5.X.

Environmental does not support Python 2.7.X so unless someone needs, we will drop support to Python 2.7.x.
