### PR TITLE
MetricWriter._renew_token can be provided with optional token_name.

### DIFF
--- a/metricz/__init__.py
+++ b/metricz/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.1.5.1'
+__version__ = '0.1.5.2'
 
 from .metricz import MetricWriter, OAUTH2_ACCESS_TOKEN_URL, CREDENTIALS_DIR  # noqa

--- a/metricz/metricz.py
+++ b/metricz/metricz.py
@@ -44,6 +44,7 @@ class MetricWriter(object):
                  url=os.environ.get('OAUTH2_ACCESS_TOKEN_URL', OAUTH2_ACCESS_TOKEN_URL),
                  directory=os.environ.get('CREDENTIALS_DIR', CREDENTIALS_DIR),
                  kairosdb_url=os.environ.get('KAIROSDB_URL', KAIROSDB_URL),
+                 uid='uid',
                  fail_silently=True,
                  timeout=4):
         tokens.configure(url=url, dir=directory)
@@ -53,20 +54,21 @@ class MetricWriter(object):
         self.fail_silently = fail_silently
         self.requests = requests.session()
         self.timeout = timeout
-        self._renew_token()
+        self._renew_token(uid)
         self.deferred_metrics = []
         self.kairosdb_url = kairosdb_url
 
-    def _renew_token(self):
+    def _renew_token(self, uid):
         """
         Renews the oauth2 token if it's older than the renewal period.
 
+        :param uid: uid to get the token for.
         :return: None
         :rtype: None
         """
         now = datetime.datetime.utcnow()
         if not self.token_ts or (now - TOKEN_RENEWAL_PERIOD) > self.token_ts:
-            token = tokens.get('uid')
+            token = tokens.get(uid)
             self.token_ts = now
             self.requests.headers.update({
                 'Authorization': 'Bearer {}'.format(token)

--- a/metricz/metricz.py
+++ b/metricz/metricz.py
@@ -44,7 +44,7 @@ class MetricWriter(object):
                  url=os.environ.get('OAUTH2_ACCESS_TOKEN_URL', OAUTH2_ACCESS_TOKEN_URL),
                  directory=os.environ.get('CREDENTIALS_DIR', CREDENTIALS_DIR),
                  kairosdb_url=os.environ.get('KAIROSDB_URL', KAIROSDB_URL),
-                 uid='uid',
+                 token_name='uid',
                  fail_silently=True,
                  timeout=4):
         tokens.configure(url=url, dir=directory)
@@ -54,21 +54,21 @@ class MetricWriter(object):
         self.fail_silently = fail_silently
         self.requests = requests.session()
         self.timeout = timeout
-        self._renew_token(uid)
+        self._renew_token(token_name)
         self.deferred_metrics = []
         self.kairosdb_url = kairosdb_url
 
-    def _renew_token(self, uid):
+    def _renew_token(self, token_name='uid'):
         """
         Renews the oauth2 token if it's older than the renewal period.
 
-        :param uid: uid to get the token for.
+        :param token_name: token_name to get the token for.
         :return: None
         :rtype: None
         """
         now = datetime.datetime.utcnow()
         if not self.token_ts or (now - TOKEN_RENEWAL_PERIOD) > self.token_ts:
-            token = tokens.get(uid)
+            token = tokens.get(token_name)
             self.token_ts = now
             self.requests.headers.update({
                 'Authorization': 'Bearer {}'.format(token)


### PR DESCRIPTION
MetricWriter._renew_token can be provided with optional token_name.